### PR TITLE
innerText vs textContent check added

### DIFF
--- a/src/js/CoachMark.js
+++ b/src/js/CoachMark.js
@@ -36,9 +36,14 @@ export default class CoachMark {
 		const titleText = document.createElement('div');
 
 		titleText.className = 'title';
-		if(opts.title) titleText.innerText = opts.title;
 
-		close.innerText = '✕';
+                //temp, move this check to a better place, better test element
+                const internalText=('textContent' in titleText)?'textContent':'innerText';
+
+		if(opts.title) titleText[internalText] = opts.title;
+
+		close[internalText] = '✕';
+                //close.setAttribute('aria-label','close');
 		close.href = '#';
 		close.className = 'close_icon';
 
@@ -53,7 +58,7 @@ export default class CoachMark {
 		content.appendChild(close)
 		content.appendChild(titleText);
 		const paragraph = document.createElement('p');
-		paragraph.innerText = opts.text;
+		paragraph[internalText] = opts.text;
 		content.appendChild(paragraph);
 		content.style.position = 'relative';
 		container.appendChild(content);


### PR DESCRIPTION
This fixes Eajaz' Firefox-specific errors where the text is not rendered (and thus the arrows are also poorly positioned). The current JS used "innerText" alone to add the title and p texts. The change now checks for <a href="http://perfectionkills.com/the-poor-misunderstood-innerText/">innerText</a> or textContent (the standard and only thing Mozilla supports), 
**however** 
I don't believe this is the best place for this check, as it would need to be repeated throughout any components adding text content to elements. Thoughts on that?