### PR TITLE
changed close anchor to a button

### DIFF
--- a/src/js/CoachMark.js
+++ b/src/js/CoachMark.js
@@ -32,15 +32,23 @@ export default class CoachMark {
 
 		//Build html
 		const container = document.createElement('div');
-		const close = document.createElement('a');
+		const close = document.createElement('button');
+		const closeSpan = document.createElement('span');
 		const titleText = document.createElement('div');
 
 		titleText.className = 'title';
-		if(opts.title) titleText.innerText = opts.title;
+                //temp, move this check to a better place, better test element  
+                const internalText=('textContent' in titleText)?'textContent':'innerText';
 
-		close.innerText = '✕';
-		close.href = '#';
+                if(opts.title) titleText[internalText] = opts.title;
+
+		close.setAttribute('type','button');
+                close.setAttribute('aria-label','close');
 		close.className = 'close_icon';
+
+                closeSpan[internalText] = '✕';
+                closeSpan.setAttribute('aria-hidden','true');
+		close.appendChild(closeSpan);
 
 		container.className = 'o-coach-mark__container';
 		container.style.visibility = 'hidden';
@@ -53,7 +61,7 @@ export default class CoachMark {
 		content.appendChild(close)
 		content.appendChild(titleText);
 		const paragraph = document.createElement('p');
-		paragraph.innerText = opts.text;
+                paragraph[internalText] = opts.text;
 		content.appendChild(paragraph);
 		content.style.position = 'relative';
 		container.appendChild(content);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -9,7 +9,7 @@
 
 			.close_icon {
 				float: right;
-				color: #000;
+				color: #000000;
 				margin: 0;
                                 padding: 5px;
                                 background-color: transparent;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -9,9 +9,12 @@
 
 			.close_icon {
 				float: right;
-				text-decoration: none;
-				color: black;
-				margin: 5px;
+				color: #000;
+				margin: 0;
+                                padding: 5px;
+                                background-color: transparent;
+                                border: 0;
+                                cursor: pointer;
 			}
 
 			.title {

--- a/test/CoachMark.test.js
+++ b/test/CoachMark.test.js
@@ -126,11 +126,11 @@ describe('CoachMark', () => {
 			title: 'foo',
 			text: 'bar'
 		}, function() { called = true; });
-		const link = document.querySelector('.o-coach-mark__container a');
+		const button = document.querySelector('.o-coach-mark__container button');
 
 		const ev = document.createEvent("MouseEvent");
 		ev.initMouseEvent("click", true, true, window);
-		link.dispatchEvent(ev);
+		button.dispatchEvent(ev);
 		expect(called).to.be(true);
 	});
 });


### PR DESCRIPTION
This branch has the same changes as the COCO-118-Gecko-text-fix; couldn't find a good way to separate these.
Close anchor turned into a button, as buttons DoStuff and anchors NavigateAway. Also wrapped the &times; element in an aria-hidden span and added aria-label="close" so the Accessible Name of the button becomes "Close" and the X/times/multiplication/whatever is not read out by screen readers.