### PR TITLE
Change selectors to match BEM convention

### DIFF
--- a/src/js/CoachMark.js
+++ b/src/js/CoachMark.js
@@ -35,12 +35,12 @@ export default class CoachMark {
 		const close = document.createElement('a');
 		const titleText = document.createElement('div');
 
-		titleText.className = 'title';
+		titleText.className = 'o-coach-mark__title';
 		if(opts.title) titleText.innerText = opts.title;
 
 		close.innerText = '✕';
 		close.href = '#';
-		close.className = 'close_icon';
+		close.className = 'o-coach-mark__close-icon';
 
 		container.className = 'o-coach-mark__container';
 		container.style.visibility = 'hidden';

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,16 +7,18 @@
 			z-index: 910;
 			font-size: 18px;
 
-			.close_icon {
-				float: right;
-				text-decoration: none;
-				color: black;
-				margin: 5px;
-			}
 
-			.title {
-				padding-bottom: 7px;
-			}
+		}
+
+		&__close-icon {
+			float: right;
+			text-decoration: none;
+			color: black;
+			margin: 5px;
+		}
+
+		&__title {
+			padding-bottom: 7px;
 		}
 
 		&__content {


### PR DESCRIPTION
Change nested `.title` and `.close_icon` selectors to match Origami BEM convention.

@jumolis @StommePoes @dstack 